### PR TITLE
Support Deephaven 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ of Docker, `host` should be set to `host.docker.internal`.
 communicates on.  This value can be found in the [IB Trader Workstation (TWS)](https://www.interactivebrokers.com/en/trading/tws.php)
 settings.  By default, production trading uses port 7496, and paper trading uses port 7497.  See [Setup](#setup) and [TWS Initial Setup](https://interactivebrokers.github.io/tws-api/initial_setup.html) for more details.
 
+`order_id_strategy` is the strategy used for obtaining new order ids.
+* `OrderIdStrategy.RETRY` (default) - Request a new order ID from TWS every time one is needed.  Retry if TWS does not respond quickly.  This usually avoids a TWS bug where it does not always respond.
+* `OrderIdStrategy.BASIC` - Request a new order ID from TWS every time one is needed.  Does not retry, so it may deadlock if TWS does not respond.
+* `OrderIdStrategy.INCREMENT` - Use the initial order ID sent by TWS and increment the value upon every request.  This is fast, but it may fail for multiple, concurrent sessions connected to TWS.
+
 ```python
 import deephaven_ib as dhib
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ See [Access your file system with Docker data volumes](https://deephaven.io/core
 
 Follow these steps to run a [Deephaven](https://deephaven.io) plus [Interactive Brokers](https://interactivebrokers.com) system. 
 
-`<deephaven_version>` is the version of [Deephaven](https://deephaven.io) to run (e.g., `0.9.0`).  A list of available versions 
+`<deephaven_version>` is the version of [Deephaven](https://deephaven.io) to run (e.g., `0.10.0`).  A list of available versions 
 can be found on the [Deephaven Releases GitHub page](https://github.com/deephaven/deephaven-core/releases).
 
 **Windows users need to run the commands in WSL.**

--- a/src/deephaven_ib/__init__.py
+++ b/src/deephaven_ib/__init__.py
@@ -8,10 +8,11 @@ from ibapi.order import Order
 
 from ._query_inputs import *
 from ._tws import IbTwsClient
+from ._tws.order_id_queue import OrderIdStrategy
 from .time import dh_to_ib_datetime
 
-__all__ = ["MarketDataType", "TickDataType", "BarDataType", "BarSize", "Duration", "Request", "RegisteredContract",
-           "IbSessionTws"]
+__all__ = ["MarketDataType", "TickDataType", "BarDataType", "BarSize", "Duration", "OrderIdStrategy",
+           "Request", "RegisteredContract", "IbSessionTws"]
 
 
 class MarketDataType(Enum):
@@ -240,23 +241,6 @@ class Duration:
 
     def __repr__(self) -> str:
         return f"Duration('{self.value}')"
-
-
-class OrderIdStrategy(Enum):
-    """Strategy used to obtain order IDs."""
-
-    def __new__(cls, retry:bool, tws_request:bool):
-        obj = bytes.__new__(cls)
-        obj.retry = retry
-        obj.tws_request = tws_request
-        return obj
-
-    INCREMENT = (False, False)
-    """Use the initial next order ID and increment the value upon every call.  This is fast, but it may fail for multiple sessions."""
-    BASIC = (False, True)
-    """Request a new order IDs from TWS every time one is needed."""
-    RETRY = (True, True)
-    """Request a new order IDs from TWS every time one is needed.  Retry if TWS does not respond quickly.  TWS seems to have a bug where it does not always respond."""
 
 
 class Request:

--- a/src/deephaven_ib/__init__.py
+++ b/src/deephaven_ib/__init__.py
@@ -393,7 +393,7 @@ class IbSessionTws:
     _tables_raw: Dict[str, Any]  # TODO: should be Dict[str, Table] with deephaven v2
     _tables: Dict[str, Any]  # TODO: should be Dict[str, Table] with deephaven v2
 
-    def __init__(self, host: str = "", port: int = 7497, client_id: int = 0, download_short_rates = True, order_id_strategy: OrderIdStrategy = OrderIdStrategy.RETRY):
+    def __init__(self, host: str = "", port: int = 7497, client_id: int = 0, download_short_rates: bool = True, order_id_strategy: OrderIdStrategy = OrderIdStrategy.RETRY):
         self._host = host
         self._port = port
         self._client_id = client_id

--- a/src/deephaven_ib/_internal/error_codes.py
+++ b/src/deephaven_ib/_internal/error_codes.py
@@ -34,7 +34,7 @@ def load_error_codes() -> Tuple[Dict[int, str], Dict[int, str]]:
         502: "Couldn't connect to TWS. Confirm that 'Enable ActiveX and Socket EClients' is enabled and connection port is the same as 'Socket Port' on the TWS 'Edit->Global Configuration...->API->Settings' menu. Live Trading ports: TWS: 7496; IB Gateway: 4001. Simulated Trading ports for new installations of version 954.1 or newer:  TWS: 7497; IB Gateway: 4002",
         2113: "The order size for Bonds (Bills) is entered as a nominal par value of the order, and must be a multiple",
         10089: "Requested market data requires additional subscription for API.See link in 'Market Data Connections' dialog for more details.",
-        10172: "Failed to request news article:No data available",
+        10172: "Failed to request news article: No data available",
         10187: "Failed to request historical ticks",
         10189: "Failed to request tick-by-tick data",
     }

--- a/src/deephaven_ib/_internal/error_codes.py
+++ b/src/deephaven_ib/_internal/error_codes.py
@@ -34,6 +34,7 @@ def load_error_codes() -> Tuple[Dict[int, str], Dict[int, str]]:
         502: "Couldn't connect to TWS. Confirm that 'Enable ActiveX and Socket EClients' is enabled and connection port is the same as 'Socket Port' on the TWS 'Edit->Global Configuration...->API->Settings' menu. Live Trading ports: TWS: 7496; IB Gateway: 4001. Simulated Trading ports for new installations of version 954.1 or newer:  TWS: 7497; IB Gateway: 4002",
         2113: "The order size for Bonds (Bills) is entered as a nominal par value of the order, and must be a multiple",
         10089: "Requested market data requires additional subscription for API.See link in 'Market Data Connections' dialog for more details.",
+        10172: "Failed to request news article:No data available",
         10187: "Failed to request historical ticks",
         10189: "Failed to request tick-by-tick data",
     }

--- a/src/deephaven_ib/_internal/tablewriter.py
+++ b/src/deephaven_ib/_internal/tablewriter.py
@@ -51,7 +51,7 @@ class TableWriter:
                 continue
 
             if (t is dht.string and not isinstance(v, str)) or \
-                    (t is dht.int32 and not isinstance(v, int)) or \
+                    (t is dht.int64 and not isinstance(v, int)) or \
                     (t is dht.float64 and not isinstance(v, float)):
                 logging.error(
                     f"TableWriter column type and value type are mismatched: column_name={n} column_type={t} value_type={type(v)} value={v}\n{trace_str()}\n-----")

--- a/src/deephaven_ib/_internal/tablewriter.py
+++ b/src/deephaven_ib/_internal/tablewriter.py
@@ -73,7 +73,7 @@ class TableWriter:
             if values[i] == "":
                 values[i] = None
 
-        self._dtw.logRow(values)
+        self._dtw.logRowPermissive(values)
 
 
 ArrayStringSet = jpy.get_type("io.deephaven.stringset.ArrayStringSet")

--- a/src/deephaven_ib/_internal/threading.py
+++ b/src/deephaven_ib/_internal/threading.py
@@ -24,7 +24,7 @@ class DeadlockMonitor:
         self.locks = {}
         self._lock = threading.Lock()
 
-        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread = threading.Thread(name="DeadlockMonitor", target=self._run, daemon=True)
         self._thread.start()
         setattr(self, "deadlock_monitor_thread", self._thread)
 

--- a/src/deephaven_ib/_internal/trace.py
+++ b/src/deephaven_ib/_internal/trace.py
@@ -1,8 +1,27 @@
 """Functionality for working with stack traces."""
 
 import traceback
-
+import threading
+import sys
 
 def trace_str() -> str:
     """Gets a string of the current stacktrace."""
     return "".join(traceback.format_stack())
+
+
+def trace_thread_str(thread:threading.Thread) -> str:
+    """Gets a string of the stacktrace of a thread."""
+    return "".join(traceback.format_stack(sys._current_frames()[thread.ident]))
+
+
+def trace_all_threads_str() -> str:
+    """Get the stacktraces for all threads as a string."""
+
+    rst = "Stack Traces:\n"
+
+    for th in threading.enumerate():
+        rst += str(th)
+        rst += trace_thread_str(th)
+        rst += "\n"
+
+    return rst

--- a/src/deephaven_ib/_tws/ib_type_logger.py
+++ b/src/deephaven_ib/_tws/ib_type_logger.py
@@ -81,7 +81,7 @@ def _details_contract() -> List[Tuple]:
         return right
 
     return [
-        ("ContractId", dht.int32, lambda contract: contract.conId),
+        ("ContractId", dht.int64, lambda contract: contract.conId),
         ("SecId", dht.string, lambda contract: contract.secId),
         ("SecIdType", dht.string, lambda contract: contract.secIdType),
         ("SecType", dht.string, lambda contract: contract.secType),
@@ -130,8 +130,8 @@ def _details_contract_details() -> List[Tuple]:
         ("MinTick", dht.float64, lambda cd: cd.minTick),
         ("OrderTypes", dht.stringset, lambda cd: to_string_set(cd.orderTypes.split(","))),
         ("ValidExchanges", dht.stringset, lambda cd: to_string_set(cd.validExchanges.split(","))),
-        ("PriceMagnifier", dht.int32, lambda cd: cd.priceMagnifier),
-        ("UnderConId", dht.int32, lambda cd: cd.underConId),
+        ("PriceMagnifier", dht.int64, lambda cd: cd.priceMagnifier),
+        ("UnderConId", dht.int64, lambda cd: cd.underConId),
         ("LongName", dht.string, lambda cd: cd.longName),
         ("ContractMonth", dht.string, lambda cd: cd.contractMonth),
         ("Industry", dht.string, lambda cd: cd.industry),
@@ -141,9 +141,9 @@ def _details_contract_details() -> List[Tuple]:
         ("TradingHours", dht.stringset, lambda cd: to_string_set(cd.tradingHours.split(";"))),
         ("LiquidHours", dht.stringset, lambda cd: to_string_set(cd.liquidHours.split(";"))),
         ("EvRule", dht.string, lambda cd: cd.evRule),
-        ("EvMultiplier", dht.int32, lambda cd: cd.evMultiplier),
-        ("MdSizeMultiplier", dht.int32, lambda cd: cd.mdSizeMultiplier),
-        ("AggGroup", dht.int32, lambda cd: map_null_int(cd.aggGroup)),
+        ("EvMultiplier", dht.int64, lambda cd: cd.evMultiplier),
+        ("MdSizeMultiplier", dht.int64, lambda cd: cd.mdSizeMultiplier),
+        ("AggGroup", dht.int64, lambda cd: map_null_int(cd.aggGroup)),
         ("UnderSymbol", dht.string, lambda cd: cd.underSymbol),
         ("UnderSecType", dht.string, lambda cd: cd.underSecType),
         ("MarketRuleIds", dht.stringset, lambda cd: to_string_set(cd.marketRuleIds.split(","))),
@@ -159,7 +159,7 @@ def _details_contract_details() -> List[Tuple]:
         ("CouponType", dht.string, lambda cd: cd.couponType),
         ("Callable", dht.bool_, lambda cd: cd.callable),
         ("Putable", dht.bool_, lambda cd: cd.putable),
-        ("Coupon", dht.int32, lambda cd: cd.coupon),
+        ("Coupon", dht.int64, lambda cd: cd.coupon),
         ("Convertible", dht.bool_, lambda cd: cd.convertible),
         ("Maturity", dht.string, lambda cd: cd.maturity),
         # TODO: convert date time?  Values are not provided in TWS, and the format is not documented. (https://github.com/deephaven-examples/deephaven-ib/issues/10)
@@ -207,8 +207,8 @@ def _details_bar_data() -> List[Tuple]:
         ("High", dht.float64, lambda bd: bd.high),
         ("Low", dht.float64, lambda bd: bd.low),
         ("Close", dht.float64, lambda bd: bd.close),
-        ("Volume", dht.int32, lambda bd: map_null(bd.volume)),
-        ("BarCount", dht.int32, lambda bd: map_null(bd.barCount)),
+        ("Volume", dht.int64, lambda bd: map_null(bd.volume)),
+        ("BarCount", dht.int64, lambda bd: map_null(bd.barCount)),
         ("Average", dht.float64, lambda bd: map_null(bd.average)),
     ]
 
@@ -234,9 +234,9 @@ def _details_real_time_bar_data() -> List[Tuple]:
         ("High", dht.float64, lambda bd: bd.high),
         ("Low", dht.float64, lambda bd: bd.low),
         ("Close", dht.float64, lambda bd: bd.close),
-        ("Volume", dht.int32, lambda bd: map_null(bd.volume)),
+        ("Volume", dht.int64, lambda bd: map_null(bd.volume)),
         ("WAP", dht.float64, lambda bd: map_null(bd.wap)),
-        ("Count", dht.int32, lambda bd: map_null(bd.count)),
+        ("Count", dht.int64, lambda bd: map_null(bd.count)),
     ]
 
 
@@ -319,7 +319,7 @@ def _details_historical_tick_last() -> List[Tuple]:
     return [
         ("Timestamp", dht.datetime, lambda t: unix_sec_to_dh_datetime(t.time)),
         ("Price", dht.float64, lambda t: t.price),
-        ("Size", dht.int32, lambda t: t.size),
+        ("Size", dht.int64, lambda t: t.size),
         *_include_details(_details_tick_attrib_last(), lambda t: t.tickAttribLast),
         ("Exchange", dht.string, lambda t: t.exchange),
         ("SpecialConditions", dht.stringset, lambda t: map_special_conditions(t.specialConditions))
@@ -352,8 +352,8 @@ def _details_historical_tick_bid_ask() -> List[Tuple]:
         ("Timestamp", dht.datetime, lambda t: unix_sec_to_dh_datetime(t.time)),
         ("BidPrice", dht.float64, lambda t: t.priceBid),
         ("AskPrice", dht.float64, lambda t: t.priceAsk),
-        ("BidSize", dht.int32, lambda t: t.sizeBid),
-        ("AskSize", dht.int32, lambda t: t.sizeAsk),
+        ("BidSize", dht.int64, lambda t: t.sizeBid),
+        ("AskSize", dht.int64, lambda t: t.sizeAsk),
         *_include_details(_details_tick_attrib_bid_ask(), lambda t: t.tickAttribBidAsk),
     ]
 
@@ -384,9 +384,9 @@ def _details_order() -> List[Tuple]:
     return [
 
         # order identifier
-        ("OrderId", dht.int32, lambda o: o.orderId),
-        ("ClientId", dht.int32, lambda o: o.clientId),
-        ("PermId", dht.int32, lambda o: o.permId),
+        ("OrderId", dht.int64, lambda o: o.orderId),
+        ("ClientId", dht.int64, lambda o: o.clientId),
+        ("PermId", dht.int64, lambda o: o.permId),
 
         # main order fields
         ("Action", dht.string, lambda o: o.action),
@@ -403,10 +403,10 @@ def _details_order() -> List[Tuple]:
         ("OcaType", dht.string, lambda o: map_values(o.ocaType, oca_types)),
         ("OrderRef", dht.string, lambda o: o.orderRef),
         ("Transmit", dht.bool_, lambda o: o.transmit),
-        ("ParentId", dht.int32, lambda o: o.parentId),
+        ("ParentId", dht.int64, lambda o: o.parentId),
         ("BlockOrder", dht.bool_, lambda o: o.blockOrder),
         ("SweepToFill", dht.bool_, lambda o: o.sweepToFill),
-        ("DisplaySize", dht.int32, lambda o: o.displaySize),
+        ("DisplaySize", dht.int64, lambda o: o.displaySize),
         ("TriggerMethod", dht.string, lambda o: map_values(o.triggerMethod, trigger_methods)),
         ("OutsideRth", dht.bool_, lambda o: o.outsideRth),
         ("Hidden", dht.bool_, lambda o: o.hidden),
@@ -414,7 +414,7 @@ def _details_order() -> List[Tuple]:
         ("GoodTillDate", dht.string, lambda o: o.goodTillDate),
         ("Rule80A", dht.string, lambda o: map_values(o.rule80A, rule80_values)),
         ("AllOrNone", dht.bool_, lambda o: o.allOrNone),
-        ("MinQty", dht.int32, lambda o: o.minQty),
+        ("MinQty", dht.int64, lambda o: o.minQty),
         ("PercentOffset", dht.float64, lambda o: o.percentOffset),
         ("OverridePercentageConstraints", dht.bool_, lambda o: o.overridePercentageConstraints),
         ("TrailStopPrice", dht.float64, lambda o: o.trailStopPrice),
@@ -431,7 +431,7 @@ def _details_order() -> List[Tuple]:
         ("OpenClose", dht.string, lambda o: map_values(o.openClose, open_close_values)),
         ("Origin", dht.string, lambda o: map_values(o.origin, origin_values)),
         ("ShortSaleSlot", dht.string, lambda o: map_values(o.shortSaleSlot, short_sale_slot_values)),
-        ("ExemptCode", dht.int32, lambda o: o.exemptCode),
+        ("ExemptCode", dht.int64, lambda o: o.exemptCode),
 
         # SMART routing only
         ("DiscretionaryAmt", dht.float64, lambda o: o.discretionaryAmt),
@@ -458,31 +458,31 @@ def _details_order() -> List[Tuple]:
         ("VolatilityType", dht.string, lambda o: map_values(o.volatilityType, volatility_type)),
         ("DeltaNeutralOrderType", dht.string, lambda o: o.deltaNeutralOrderType),
         ("DeltaNeutralAuxPrice", dht.float64, lambda o: o.deltaNeutralAuxPrice),
-        ("DeltaNeutralConId", dht.int32, lambda o: o.deltaNeutralConId),
+        ("DeltaNeutralConId", dht.int64, lambda o: o.deltaNeutralConId),
         ("DeltaNeutralSettlingFirm", dht.string, lambda o: o.deltaNeutralSettlingFirm),
         ("DeltaNeutralClearingAccount", dht.string, lambda o: o.deltaNeutralClearingAccount),
         ("DeltaNeutralClearingIntent", dht.string, lambda o: o.deltaNeutralClearingIntent),
         ("DeltaNeutralOpenClose", dht.string, lambda o: o.deltaNeutralOpenClose),
         ("DeltaNeutralShortSale", dht.bool_, lambda o: o.deltaNeutralShortSale),
-        ("DeltaNeutralShortSaleSlot", dht.int32, lambda o: o.deltaNeutralShortSaleSlot),
+        ("DeltaNeutralShortSaleSlot", dht.int64, lambda o: o.deltaNeutralShortSaleSlot),
         ("DeltaNeutralDesignatedLocation", dht.string, lambda o: o.deltaNeutralDesignatedLocation),
         ("ContinuousUpdate", dht.bool_, lambda o: o.continuousUpdate),
         ("ReferencePriceType", dht.string, lambda o: map_values(o.referencePriceType, reference_price_type)),
 
         # COMBO ORDERS ONLY
         ("BasisPoints", dht.float64, lambda o: o.basisPoints),
-        ("BasisPointsType", dht.int32, lambda o: o.basisPointsType),
+        ("BasisPointsType", dht.int64, lambda o: o.basisPointsType),
 
         # SCALE ORDERS ONLY
-        ("ScaleInitLevelSize", dht.int32, lambda o: o.scaleInitLevelSize),
-        ("ScaleSubsLevelSize", dht.int32, lambda o: o.scaleSubsLevelSize),
+        ("ScaleInitLevelSize", dht.int64, lambda o: o.scaleInitLevelSize),
+        ("ScaleSubsLevelSize", dht.int64, lambda o: o.scaleSubsLevelSize),
         ("ScalePriceIncrement", dht.float64, lambda o: o.scalePriceIncrement),
         ("ScalePriceAdjustValue", dht.float64, lambda o: o.scalePriceAdjustValue),
-        ("ScalePriceAdjustInterval", dht.int32, lambda o: o.scalePriceAdjustInterval),
+        ("ScalePriceAdjustInterval", dht.int64, lambda o: o.scalePriceAdjustInterval),
         ("ScaleProfitOffset", dht.float64, lambda o: o.scaleProfitOffset),
         ("ScaleAutoReset", dht.bool_, lambda o: o.scaleAutoReset),
-        ("ScaleInitPosition", dht.int32, lambda o: o.scaleInitPosition),
-        ("ScaleInitFillQty", dht.int32, lambda o: o.scaleInitFillQty),
+        ("ScaleInitPosition", dht.int64, lambda o: o.scaleInitPosition),
+        ("ScaleInitFillQty", dht.int64, lambda o: o.scaleInitFillQty),
         ("ScaleRandomPercent", dht.bool_, lambda o: o.scaleRandomPercent),
         ("ScaleTable", dht.string, lambda o: o.scaleTable),
 
@@ -521,7 +521,7 @@ def _details_order() -> List[Tuple]:
         ("OrderMiscOptions", dht.stringset, lambda o: to_string_set(o.orderMiscOptions)),
 
         # VER PEG2BENCH fields:
-        ("ReferenceContractId", dht.int32, lambda o: o.referenceContractId),
+        ("ReferenceContractId", dht.int64, lambda o: o.referenceContractId),
         ("PeggedChangeAmount", dht.float64, lambda o: o.peggedChangeAmount),
         ("IsPeggedChangeAmountDecrease", dht.bool_, lambda o: o.isPeggedChangeAmountDecrease),
         ("ReferenceChangeAmount", dht.float64, lambda o: o.referenceChangeAmount),
@@ -532,7 +532,7 @@ def _details_order() -> List[Tuple]:
         ("AdjustedStopPrice", dht.float64, lambda o: o.adjustedStopPrice),
         ("AdjustedStopLimitPrice", dht.float64, lambda o: o.adjustedStopLimitPrice),
         ("AdjustedTrailingAmount", dht.float64, lambda o: o.adjustedTrailingAmount),
-        ("AdjustableTrailingUnit", dht.int32, lambda o: o.adjustableTrailingUnit),
+        ("AdjustableTrailingUnit", dht.int64, lambda o: o.adjustableTrailingUnit),
         ("LmtPriceOffset", dht.float64, lambda o: o.lmtPriceOffset),
 
         ("Conditions", dht.stringset, lambda o: to_string_set(o.conditions)),
@@ -558,12 +558,12 @@ def _details_order() -> List[Tuple]:
 
         ("AutoCancelDate", dht.string, lambda o: o.autoCancelDate),
         ("FilledQuantity", dht.float64, lambda o: o.filledQuantity),
-        ("RefFuturesConId", dht.int32, lambda o: o.refFuturesConId),
+        ("RefFuturesConId", dht.int64, lambda o: o.refFuturesConId),
         ("AutoCancelParent", dht.bool_, lambda o: o.autoCancelParent),
         ("Shareholder", dht.string, lambda o: o.shareholder),
         ("ImbalanceOnly", dht.bool_, lambda o: o.imbalanceOnly),
         ("RouteMarketableToBbo", dht.bool_, lambda o: o.routeMarketableToBbo),
-        ("ParentPermId", dht.int32, lambda o: o.parentPermId),
+        ("ParentPermId", dht.int64, lambda o: o.parentPermId),
 
         ("UsePriceMgmtAlgo", dht.bool_, lambda o: o.usePriceMgmtAlgo),
 
@@ -619,17 +619,17 @@ def _details_execution() -> List[Tuple]:
         ("Side", dht.string, lambda e: e.side),
         ("Shares", dht.float64, lambda e: e.shares),
         ("Price", dht.float64, lambda e: e.price),
-        ("PermId", dht.int32, lambda e: e.permId),
-        ("ClientId", dht.int32, lambda e: e.clientId),
-        ("OrderId", dht.int32, lambda e: e.orderId),
-        ("Liquidation", dht.int32, lambda e: e.liquidation),
+        ("PermId", dht.int64, lambda e: e.permId),
+        ("ClientId", dht.int64, lambda e: e.clientId),
+        ("OrderId", dht.int64, lambda e: e.orderId),
+        ("Liquidation", dht.int64, lambda e: e.liquidation),
         ("CumQty", dht.float64, lambda e: e.cumQty),
         ("AvgPrice", dht.float64, lambda e: e.avgPrice),
         ("OrderRef", dht.string, lambda e: e.orderRef),
         ("EvRule", dht.string, lambda e: e.evRule),
         ("EvMultiplier", dht.float64, lambda e: e.evMultiplier),
         ("ModelCode", dht.string, lambda e: e.modelCode),
-        ("LastLiquidity", dht.int32, lambda e: e.lastLiquidity),
+        ("LastLiquidity", dht.int64, lambda e: e.lastLiquidity),
     ]
 
 

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -58,6 +58,7 @@ class OrderIdEventQueue:
         self._values = []
         self._lock = LoggingLock("OrderIdEventQueue")
         self._request_thread = Thread(target=self._run, daemon=True)
+        self._request_thread.start()
         self._client = client
 
     def _run(self):

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class OrderIdStrategy(Enum):
     """Strategy used to obtain order IDs."""
 
-    def __new__(cls, retry:bool, tws_request:bool):
+    def __new__(cls, retry: bool, tws_request: bool):
         obj = object.__new__(cls)
         obj.retry = retry
         obj.tws_request = tws_request
@@ -53,7 +53,7 @@ class OrderIdRequest:
 
         if not event_happened:
             trace = trace_all_threads_str()
-            msg = f"OrderIdRequest.get() timed out after {time_out} sec.  A possible deadlock or TWS bug was detected!  Please create an issue at https://github.com/deephaven-examples/deephaven-ib/issues containing this error message\n{trace}\n"
+            msg = f"OrderIdRequest.get() timed out after {time_out} sec.  A possible deadlock or TWS bug was detected!  You may be able to avoid this problem by using a different OrderIdStrategy.  Please create an issue at https://github.com/deephaven-examples/deephaven-ib/issues containing this error message\n{trace}\n"
             raise Exception(msg)
 
         with self._lock:
@@ -73,7 +73,7 @@ class OrderIdEventQueue:
     _last_value: int
     _request_thread: Thread
 
-    def __init__(self, client: 'IbTwsClient', strategy:OrderIdStrategy = OrderIdStrategy.RETRY):
+    def __init__(self, client: 'IbTwsClient', strategy: OrderIdStrategy = OrderIdStrategy.RETRY):
         self._events = []
         self._values = []
         self._lock = LoggingLock("OrderIdEventQueue")

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -63,7 +63,8 @@ class OrderIdEventQueue:
     def _run(self):
         """Re-requests IDs if there is no response."""
         while True:
-            for _ in range(len(self._events)):
+            for event in self._events:
+                print(f"DEBUG: rerequest: event={event}")
                 self._client.reqIds(-1)
 
             sleep(0.01)

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from .tws_client import IbTwsClient
 
 
-
 class OrderIdRequest:
     """An order ID request."""
 

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -31,6 +31,7 @@ class OrderIdRequest:
         """A blocking call to get the order ID."""
 
         time_out = 2 * 60.0
+        print(f"DEBUG: get: event={self._event}")
         event_happened = self._event.wait(time_out)
 
         if not event_happened:
@@ -64,6 +65,7 @@ class OrderIdEventQueue:
         with self._lock:
             self._events.append(event)
 
+        print(f"DEBUG: request: event={event}")
         self._client.reqIds(-1)
 
         return OrderIdRequest(event, self._get)
@@ -73,9 +75,11 @@ class OrderIdEventQueue:
 
         with self._lock:
             # if is to filter out values requested by ibapi during initialization
+            print(f"DEBUG: add_value: events={self._events}")
             if self._events:
                 self._values.append(value)
                 event = self._events.pop(0)
+                print(f"DEBUG: add_value: event={event} value={value}")
                 event.set()
 
     def _get(self) -> int:

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -2,16 +2,33 @@
 
 from threading import Event, Thread
 from time import sleep
+from enum import Enum
 from typing import List, Callable, TYPE_CHECKING
 
 from .._internal.threading import LoggingLock
 from .._internal.trace import trace_all_threads_str
-from .. import OrderIdStrategy
 
 # Type hints on IbTwsClient cause a circular dependency.
 # This conditional import plus a string-based annotation avoids the problem.
 if TYPE_CHECKING:
     from .tws_client import IbTwsClient
+
+
+class OrderIdStrategy(Enum):
+    """Strategy used to obtain order IDs."""
+
+    def __new__(cls, retry:bool, tws_request:bool):
+        obj = bytes.__new__(cls)
+        obj.retry = retry
+        obj.tws_request = tws_request
+        return obj
+
+    INCREMENT = (False, False)
+    """Use the initial next order ID and increment the value upon every call.  This is fast, but it may fail for multiple sessions."""
+    BASIC = (False, True)
+    """Request a new order IDs from TWS every time one is needed."""
+    RETRY = (True, True)
+    """Request a new order IDs from TWS every time one is needed.  Retry if TWS does not respond quickly.  TWS seems to have a bug where it does not always respond."""
 
 
 class OrderIdRequest:

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -6,6 +6,7 @@ from typing import List, Callable
 from typing import TYPE_CHECKING
 
 from .._internal.threading import LoggingLock
+from .._internal.trace import trace_all_threads_str
 
 # Type hints on IbTwsClient cause a circular dependency.
 # This conditional import plus a string-based annotation avoids the problem.
@@ -36,6 +37,9 @@ class OrderIdRequest:
         event_happened = self._event.wait(time_out)
 
         if not event_happened:
+            #TODO: debug remove
+            trace = trace_all_threads_str()
+            print(trace)
             raise Exception(f"OrderIdRequest.get() timed out after {time_out} sec.")
 
         with self._lock:

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -18,7 +18,7 @@ class OrderIdStrategy(Enum):
     """Strategy used to obtain order IDs."""
 
     def __new__(cls, retry:bool, tws_request:bool):
-        obj = bytes.__new__(cls)
+        obj = object.__new__(cls)
         obj.retry = retry
         obj.tws_request = tws_request
         return obj

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -57,7 +57,7 @@ class OrderIdEventQueue:
         self._events = []
         self._values = []
         self._lock = LoggingLock("OrderIdEventQueue")
-        self._request_thread = Thread(target=self._run, daemon=True)
+        self._request_thread = Thread(name="OrderIdEventQueueRetry", target=self._run, daemon=True)
         self._request_thread.start()
         self._client = client
 

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -24,11 +24,11 @@ class OrderIdStrategy(Enum):
         return obj
 
     INCREMENT = (False, False)
-    """Use the initial next order ID and increment the value upon every call.  This is fast, but it may fail for multiple sessions."""
+    """Use the initial order ID and increment the value upon every call.  This is fast, but it may fail for multiple, concurrent sessions."""
     BASIC = (False, True)
-    """Request a new order IDs from TWS every time one is needed."""
+    """Request a new order ID from TWS every time one is needed."""
     RETRY = (True, True)
-    """Request a new order IDs from TWS every time one is needed.  Retry if TWS does not respond quickly.  TWS seems to have a bug where it does not always respond."""
+    """Request a new order ID from TWS every time one is needed.  Retry if TWS does not respond quickly.  TWS seems to have a bug where it does not always respond."""
 
 
 class OrderIdRequest:

--- a/src/deephaven_ib/_tws/order_id_queue.py
+++ b/src/deephaven_ib/_tws/order_id_queue.py
@@ -6,7 +6,7 @@ from typing import List, Callable, TYPE_CHECKING
 
 from .._internal.threading import LoggingLock
 from .._internal.trace import trace_all_threads_str
-from ..__init__ import OrderIdStrategy
+from .. import OrderIdStrategy
 
 # Type hints on IbTwsClient cause a circular dependency.
 # This conditional import plus a string-based annotation avoids the problem.

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -31,7 +31,7 @@ from .._internal.error_codes import load_error_codes
 from .._internal.short_rates import load_short_rates
 from .._internal.tablewriter import TableWriter
 from ..time import unix_sec_to_dh_datetime
-from ..__init__ import OrderIdStrategy
+from .. import OrderIdStrategy
 
 _error_code_message_map, _error_code_note_map = load_error_codes()
 _news_msgtype_map: Dict[int, str] = {news.NEWS_MSG: "NEWS", news.EXCHANGE_AVAIL_MSG: "EXCHANGE_AVAILABLE",

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -317,7 +317,7 @@ class IbTwsClient(EWrapper, EClient):
         # wait for the client to connect to avoid a race condition (https://github.com/deephaven-examples/deephaven-ib/issues/12)
         time.sleep(1)
 
-        self._thread = Thread(name="TwsClient", target=self.run)
+        self._thread = Thread(name="IbTwsClient", target=self.run)
         self._thread.start()
         setattr(self, "ib_thread", self._thread)
 

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -74,7 +74,7 @@ class IbTwsClient(EWrapper, EClient):
     _accounts_managed: Set[str]
     _order_id_strategy: OrderIdStrategy
 
-    def __init__(self, download_short_rates, order_id_strategy:OrderIdStrategy):
+    def __init__(self, download_short_rates: bool, order_id_strategy: OrderIdStrategy):
         EWrapper.__init__(self)
         EClient.__init__(self, wrapper=self)
         self._table_writers = IbTwsClient._build_table_writers()

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -31,6 +31,7 @@ from .._internal.error_codes import load_error_codes
 from .._internal.short_rates import load_short_rates
 from .._internal.tablewriter import TableWriter
 from ..time import unix_sec_to_dh_datetime
+from ..__init__ import OrderIdStrategy
 
 _error_code_message_map, _error_code_note_map = load_error_codes()
 _news_msgtype_map: Dict[int, str] = {news.NEWS_MSG: "NEWS", news.EXCHANGE_AVAIL_MSG: "EXCHANGE_AVAILABLE",
@@ -71,8 +72,9 @@ class IbTwsClient(EWrapper, EClient):
     _realtime_bar_sizes: Dict[TickerId, int]
     news_providers: List[str]
     _accounts_managed: Set[str]
+    _order_id_strategy: OrderIdStrategy
 
-    def __init__(self, download_short_rates=True):
+    def __init__(self, download_short_rates, order_id_strategy:OrderIdStrategy):
         EWrapper.__init__(self)
         EClient.__init__(self, wrapper=self)
         self._table_writers = IbTwsClient._build_table_writers()
@@ -84,6 +86,7 @@ class IbTwsClient(EWrapper, EClient):
         self._realtime_bar_sizes = None
         self.news_providers = None
         self._accounts_managed = None
+        self._order_id_strategy = order_id_strategy
 
         tables = {name: tw.table() for (name, tw) in self._table_writers.items()}
 
@@ -304,7 +307,7 @@ class IbTwsClient(EWrapper, EClient):
             raise Exception("IbTwsClient is already connected.")
 
         self.contract_registry = ContractRegistry(self)
-        self.order_id_queue = OrderIdEventQueue(self)
+        self.order_id_queue = OrderIdEventQueue(self, strategy=self._order_id_strategy)
         self._registered_market_rules = set()
         self._realtime_bar_sizes = {}
         self.news_providers = []

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -315,7 +315,7 @@ class IbTwsClient(EWrapper, EClient):
         # wait for the client to connect to avoid a race condition (https://github.com/deephaven-examples/deephaven-ib/issues/12)
         time.sleep(1)
 
-        self._thread = Thread(target=self.run)
+        self._thread = Thread(name="TwsClient", target=self.run)
         self._thread.start()
         setattr(self, "ib_thread", self._thread)
 

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -111,11 +111,11 @@ class IbTwsClient(EWrapper, EClient):
         ####
 
         table_writers["requests"] = TableWriter(["RequestId", "RequestType", *logger_contract.names(), "Note"],
-                                                [dht.int32, dht.string, *logger_contract.types(), dht.string])
+                                                [dht.int64, dht.string, *logger_contract.types(), dht.string])
 
         table_writers["errors"] = TableWriter(
             ["RequestId", "ErrorCode", "ErrorDescription", "Error", "Note"],
-            [dht.int32, dht.int32, dht.string, dht.string, dht.string])
+            [dht.int64, dht.int64, dht.string, dht.string, dht.string])
 
         ####
         # Contracts
@@ -123,11 +123,11 @@ class IbTwsClient(EWrapper, EClient):
 
         table_writers["contracts_details"] = TableWriter(
             ["RequestId", *logger_contract_details.names()],
-            [dht.int32, *logger_contract_details.types()])
+            [dht.int64, *logger_contract_details.types()])
 
         table_writers["contracts_matching"] = TableWriter(
             ["RequestId", *logger_contract.names(), "DerivativeSecTypes"],
-            [dht.int32, *logger_contract.types(), dht.stringset])
+            [dht.int64, *logger_contract.types(), dht.stringset])
 
         table_writers["market_rules"] = TableWriter(
             ["MarketRuleId", *logger_price_increment.names()],
@@ -157,19 +157,19 @@ class IbTwsClient(EWrapper, EClient):
 
         table_writers["accounts_overview"] = TableWriter(
             ["RequestId", "Account", "ModelCode", "Currency", "Key", "Value"],
-            [dht.int32, dht.string, dht.string, dht.string, dht.string, dht.string])
+            [dht.int64, dht.string, dht.string, dht.string, dht.string, dht.string])
 
         table_writers["accounts_summary"] = TableWriter(
             ["RequestId", "Account", "Tag", "Value", "Currency"],
-            [dht.int32, dht.string, dht.string, dht.string, dht.string])
+            [dht.int64, dht.string, dht.string, dht.string, dht.string])
 
         table_writers["accounts_positions"] = TableWriter(
             ["RequestId", "Account", "ModelCode", *logger_contract.names(), "Position", "AvgCost"],
-            [dht.int32, dht.string, dht.string, *logger_contract.types(), dht.float64, dht.float64])
+            [dht.int64, dht.string, dht.string, *logger_contract.types(), dht.float64, dht.float64])
 
         table_writers["accounts_pnl"] = TableWriter(
             ["RequestId", "DailyPnl", "UnrealizedPnl", "RealizedPnl"],
-            [dht.int32, dht.float64, dht.float64, dht.float64])
+            [dht.int64, dht.float64, dht.float64, dht.float64])
 
         ####
         # News
@@ -179,15 +179,15 @@ class IbTwsClient(EWrapper, EClient):
 
         table_writers["news_bulletins"] = TableWriter(
             ["MsgId", "MsgType", "Message", "OriginExch"],
-            [dht.int32, dht.string, dht.string, dht.string])
+            [dht.int64, dht.string, dht.string, dht.string])
 
         table_writers["news_articles"] = TableWriter(
             ["RequestId", "ArticleType", "ArticleText"],
-            [dht.int32, dht.string, dht.string])
+            [dht.int64, dht.string, dht.string])
 
         table_writers["news_historical"] = TableWriter(
             ["RequestId", "Timestamp", "ProviderCode", "ArticleId", "Headline"],
-            [dht.int32, dht.datetime, dht.string, dht.string, dht.string])
+            [dht.int64, dht.datetime, dht.string, dht.string, dht.string])
 
         ####
         # Market Data
@@ -195,52 +195,52 @@ class IbTwsClient(EWrapper, EClient):
 
         table_writers["ticks_price"] = TableWriter(
             ["RequestId", "TickType", "Price", *logger_tick_attrib.names()],
-            [dht.int32, dht.string, dht.float64, *logger_tick_attrib.types()])
+            [dht.int64, dht.string, dht.float64, *logger_tick_attrib.types()])
 
         table_writers["ticks_size"] = TableWriter(
             ["RequestId", "TickType", "Size"],
-            [dht.int32, dht.string, dht.int32])
+            [dht.int64, dht.string, dht.int64])
 
         table_writers["ticks_string"] = TableWriter(
             ["RequestId", "TickType", "Value"],
-            [dht.int32, dht.string, dht.string])
+            [dht.int64, dht.string, dht.string])
 
         # exchange for physical
         table_writers["ticks_efp"] = TableWriter(
             ["RequestId", "TickType", "BasisPoints", "FormattedBasisPoints", "TotalDividends", "HoldDays",
              "FutureLastTradeDate", "DividendImpact", "DividendsToLastTradeDate"],
-            [dht.int32, dht.string, dht.float64, dht.string, dht.float64, dht.int32,
+            [dht.int64, dht.string, dht.float64, dht.string, dht.float64, dht.int64,
              dht.string, dht.float64, dht.float64])
 
         table_writers["ticks_generic"] = TableWriter(
             ["RequestId", "TickType", "Value"],
-            [dht.int32, dht.string, dht.float64])
+            [dht.int64, dht.string, dht.float64])
 
         table_writers["ticks_option_computation"] = TableWriter(
             ["RequestId", "TickType", "TickAttrib", "ImpliedVol", "Delta", "OptPrice", "PvDividend", "Gamma",
              "Vega", "Theta", "UndPrice"],
-            [dht.int32, dht.string, dht.string, dht.float64, dht.float64, dht.float64, dht.float64, dht.float64,
+            [dht.int64, dht.string, dht.string, dht.float64, dht.float64, dht.float64, dht.float64, dht.float64,
              dht.float64, dht.float64, dht.float64])
 
         table_writers["ticks_trade"] = TableWriter(
             ["RequestId", *logger_hist_tick_last.names()],
-            [dht.int32, *logger_hist_tick_last.types()])
+            [dht.int64, *logger_hist_tick_last.types()])
 
         table_writers["ticks_bid_ask"] = TableWriter(
             ["RequestId", *logger_hist_tick_bid_ask.names()],
-            [dht.int32, *logger_hist_tick_bid_ask.types()])
+            [dht.int64, *logger_hist_tick_bid_ask.types()])
 
         table_writers["ticks_mid_point"] = TableWriter(
             ["RequestId", "Timestamp", "MidPoint"],
-            [dht.int32, dht.datetime, dht.float64])
+            [dht.int64, dht.datetime, dht.float64])
 
         table_writers["bars_historical"] = TableWriter(
             ["RequestId", *logger_bar_data.names()],
-            [dht.int32, *logger_bar_data.types()])
+            [dht.int64, *logger_bar_data.types()])
 
         table_writers["bars_realtime"] = TableWriter(
             ["RequestId", *logger_real_time_bar_data.names()],
-            [dht.int32, *logger_real_time_bar_data.types()])
+            [dht.int64, *logger_real_time_bar_data.types()])
 
         ####
         # Order Management System (OMS)
@@ -253,8 +253,8 @@ class IbTwsClient(EWrapper, EClient):
         table_writers["orders_status"] = TableWriter(
             ["OrderId", "Status", "Filled", "Remaining", "AvgFillPrice", "PermId", "ParentId", "LastFillPrice",
              "ClientId", "WhyHeld", "MktCapPrice"],
-            [dht.int32, dht.string, dht.float64, dht.float64, dht.float64, dht.int32, dht.int32, dht.float64,
-             dht.int32, dht.string, dht.float64])
+            [dht.int64, dht.string, dht.float64, dht.float64, dht.float64, dht.int64, dht.int64, dht.float64,
+             dht.int64, dht.string, dht.float64])
 
         table_writers["orders_completed"] = TableWriter(
             [*logger_contract.names(), *logger_order.names(), *logger_order_state.names()],
@@ -263,7 +263,7 @@ class IbTwsClient(EWrapper, EClient):
         table_writers["orders_exec_details"] = TableWriter(
             ["RequestId", *logger_contract.names(renames={"Exchange": "ContractExchange"}),
              *logger_execution.names(renames={"Exchange": "ExecutionExchange"})],
-            [dht.int32, *logger_contract.types(), *logger_execution.types()])
+            [dht.int64, *logger_contract.types(), *logger_execution.types()])
 
         table_writers["orders_exec_commission_report"] = TableWriter(
             [*logger_commission_report.names()],

--- a/src/deephaven_ib/_tws/tws_client.py
+++ b/src/deephaven_ib/_tws/tws_client.py
@@ -25,13 +25,12 @@ from ratelimit import limits, sleep_and_retry
 
 from .contract_registry import ContractRegistry
 from .ib_type_logger import *
-from .order_id_queue import OrderIdEventQueue
+from .order_id_queue import OrderIdEventQueue, OrderIdStrategy
 from .requests import RequestIdManager
 from .._internal.error_codes import load_error_codes
 from .._internal.short_rates import load_short_rates
 from .._internal.tablewriter import TableWriter
 from ..time import unix_sec_to_dh_datetime
-from .. import OrderIdStrategy
 
 _error_code_message_map, _error_code_note_map = load_error_codes()
 _news_msgtype_map: Dict[int, str] = {news.NEWS_MSG: "NEWS", news.EXCHANGE_AVAIL_MSG: "EXCHANGE_AVAILABLE",


### PR DESCRIPTION
Change DynamicTableWriter from using logRow to logRowPermissive.
Added missing error code.
Use int64 instead of int32 column types.
Name threads.
Multiple algorithms for obtaining new order ids (added request and increment).  (See #8)

Deadlocks in acquiring order ids were very common in 0.10.0.   They seem to result when TWS does not respond to ID requests.