### PR TITLE
Fixed DH `_jcompat` to `jcompat` module rename

### DIFF
--- a/src/deephaven_ib/_query_inputs.py
+++ b/src/deephaven_ib/_query_inputs.py
@@ -15,7 +15,7 @@ import json
 from typing import Union
 
 import jpy
-from deephaven._jcompat import j_function
+from deephaven.jcompat import j_function
 from deephaven.constants import NULL_DOUBLE
 import deephaven.dtypes
 


### PR DESCRIPTION
Deephaven's python module has made `_jcompat` public as `jcompat`.  Appropriate changes were made.

Resolves #41 