### PR TITLE
Start the DH server in sphinx

### DIFF
--- a/sphinx/lib/dh_sphinx.py
+++ b/sphinx/lib/dh_sphinx.py
@@ -10,6 +10,7 @@ _server = None
 def setup_sphinx_environment():
     global _server
     _server = Server()
+    _server.start()
 
 
 def glob_package_names(packages):


### PR DESCRIPTION
Sphinx is not generating documentation.  This is possibly from the server not being started.