### PR TITLE
Extract a proper sever from a version tag to fix the build

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -64,7 +64,8 @@ jobs:
               echo "::set-output name=version::0.0.0.dev${PR_NUMBER}"
             fi
         else
-            echo "::set-output name=version::${{ github.event.release.tag_name }}"
+            SEMVER="${TAG_NAME:1}"
+            echo "::set-output name=version::${SEMVER}"
         fi
     - name: Build
       env:


### PR DESCRIPTION
Whls are not building because the tags are not proper semvers.  The "v" prefix needs to be stripped.