### PR TITLE
ci: Make the semver for release canddiates valid

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -58,7 +58,7 @@ jobs:
         then
             if [ "$GITHUB_REF" = "refs/heads/main" ]
             then
-              echo "::set-output name=version::0.0.0.rc"
+              echo "::set-output name=version::0.0.0.rc0"
             else
               PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
               echo "::set-output name=version::0.0.0.dev${PR_NUMBER}"


### PR DESCRIPTION
Github actions are erroring for `0.0.0.rc` as a semver.  Changing to `0.0.0.rc0`.