### PR TITLE
fix: Update Docker image from server-ui to server

### DIFF
--- a/.github/workflows/Dockerfile.server
+++ b/.github/workflows/Dockerfile.server
@@ -1,6 +1,6 @@
 ARG DH_VERSION
 
-FROM ghcr.io/deephaven/server-ui:${DH_VERSION}
+FROM ghcr.io/deephaven/server:${DH_VERSION}
 
 RUN apt update && \
     apt install -y python3-pip python3-venv curl zip && \


### PR DESCRIPTION
Changed the base Docker image from `ghcr.io/deephaven/server-ui` to `ghcr.io/deephaven/server` to use the correct Deephaven server image.