### PR TITLE
fix: Simplify version handling and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ you can use the `--use_venv false` option to [./dhib_env.py](./dhib_env.py).
 
    Install the dependencies needed to run the script into this installer virtual environment:
     ```bash
+    pip --upgrade pip
     pip install -r requirements_dhib_env.txt
     ```
 
@@ -211,17 +212,17 @@ you can use the `--use_venv false` option to [./dhib_env.py](./dhib_env.py).
     python ./dhib_env.py --help
     ```
 
-   To install the latest production release version of [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) from PyPi plus the release-specified `ibapi` and `deephaven` versions: 
+   To install the latest production release version of [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) from PyPI. This command will automatically install the latest `deephaven-server` from PyPI and extract the required `ibapi` version from the deephaven-ib package dependencies: 
     ```bash
     python ./dhib_env.py release
     ```
    
-   To install the latest development version of [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) from source plus the default `ibapi` and `deephaven` versions:
+   To install the latest development version of [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) from source. This command will automatically install the latest `deephaven-server` and `ibapi` versions from PyPI:
     ```bash
     python ./dhib_env.py dev
     ```
 
-   To create a venv for developing [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) in PyCharm: (This will not install `deephaven-ib`, but it will install the default `ibapi` and `deephaven` versions.)
+   To create a venv for developing [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) in PyCharm: (This will not install `deephaven-ib`, but it will install the latest `deephaven-server` and `ibapi` versions from PyPI.)
     ```bash
     python ./dhib_env.py dev --install_dhib false
     ```

--- a/dhib_env.py
+++ b/dhib_env.py
@@ -4,8 +4,8 @@
 
 import sys
 
-if sys.version_info < (3, 11):
-    raise RuntimeError(f"This script requires Python 3.11 or higher. You are using Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
+if sys.version_info < (3, 10):
+    raise RuntimeError(f"This script requires Python 3.10 or higher. You are using Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
 
 import atexit
 import logging

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,6 @@ dh_ib_version = os.getenv("DH_IB_VERSION")
 if not dh_ib_version:
     raise Exception("deephaven-ib version must be set via the DH_IB_VERSION environment variable.")
 
-dh_version = os.getenv("DH_VERSION")
-
-if not dh_version:
-    raise Exception("deephaven version must be set via the DH_VERSION environment variable.")
-
 ib_version = os.getenv("IB_VERSION")
 
 if not ib_version:
@@ -59,7 +54,6 @@ def version_assert_format(version: str, allow_zero_prefix: bool=False) -> None:
 
 
 version_assert_format(dh_ib_version)
-version_assert_format(dh_version)
 version_assert_format(ib_version, allow_zero_prefix=True)
 
 setuptools.setup(
@@ -91,7 +85,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.10",
     install_requires=[
-        f"deephaven-server>={dh_version}",
+        "deephaven-server",
         "pandas",
         f"ibapi=={ib_version}",
         "lxml",


### PR DESCRIPTION
Simplify Deephaven version handling and improve dependency management

- Remove hardcoded `DH_VERSION_DEFAULT` and make Deephaven version optional, defaulting to latest from PyPI
- Add `get_latest_version()` helper function to fetch latest package versions from PyPI
- Remove `DH_VERSION` environment variable requirement from `setup.py` and make `deephaven-server` dependency version-agnostic
- Fix dependency parsing regex in `pkg_dependencies()` to handle complex version specifiers
- Update README