### PR TITLE
fix: Fix build script bugs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ you can use the `--use_venv false` option to [./dhib_env.py](./dhib_env.py).
     ```
 4) Build a [deephaven-ib](https://github.com/deephaven-examples/deephaven-ib) virtual environment:
 
+   **Quick Start:** For a one-command setup that builds the environment and starts the server, use the convenience script:
+    ```bash
+    ./build_and_run.sh
+    ```
+   This script automatically creates the virtual environment, installs the latest release version, and starts the Deephaven server. Press Ctrl-C to stop the server when done.
+
+   **Manual Setup:** For more control over the installation process, follow these steps:
+
    First, create a small, local virtual environment that will be used only to run the `dhib_env.py` script (this avoids installing packages system-wide):
     ```bash
     python3 -m venv .venv-installer
@@ -201,7 +209,7 @@ you can use the `--use_venv false` option to [./dhib_env.py](./dhib_env.py).
 
    Install the dependencies needed to run the script into this installer virtual environment:
     ```bash
-    pip --upgrade pip
+    python -m pip install --upgrade pip
     pip install -r requirements_dhib_env.txt
     ```
 

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Convenience script to build a release virtual environment and start the Deephaven server.
+# This script automates the process of:
+# 1. Creating a temporary installer virtual environment
+# 2. Building the release virtual environment with deephaven-ib, deephaven-server, and ibapi
+# 3. Starting the Deephaven server
+#
+# Press Ctrl-C to stop the server when done.
+
+# Display Java home (required for Deephaven)
+echo $JAVA_HOME
+
+# Clean up any existing virtual environments
+deactivate 2>/dev/null || true  # Deactivate if already in a venv
+rm -rf .venv-installer
+rm -rf venv-release-dhib*
+
+# Create temporary installer virtual environment
+# This small venv is only used to run the dhib_env.py script
+python3.12 -m venv .venv-installer
+source .venv-installer/bin/activate
+
+# Install dependencies needed to run dhib_env.py
+python -m pip install --upgrade pip
+pip install -r requirements_dhib_env.txt
+
+# Build the release virtual environment
+# This creates venv-release-dhib-<version> with all required packages
+python ./dhib_env.py release 
+
+# Clean up temporary installer venv
+deactivate
+rm -rf .venv-installer
+
+# Activate the release virtual environment and start Deephaven server
+source ./venv-release-dhib*/bin/activate
+deephaven server
+deactivate

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -9,7 +9,11 @@
 # Press Ctrl-C to stop the server when done.
 
 # Display Java home (required for Deephaven)
-echo $JAVA_HOME
+if [ -z "${JAVA_HOME:-}" ]; then
+    echo "Error: JAVA_HOME is not set. Deephaven requires Java. Please set JAVA_HOME before running this script." >&2
+    exit 1
+fi
+echo "JAVA_HOME=${JAVA_HOME}"
 
 # Clean up any existing virtual environments
 deactivate 2>/dev/null || true  # Deactivate if already in a venv
@@ -35,5 +39,6 @@ rm -rf .venv-installer
 
 # Activate the release virtual environment and start Deephaven server
 source ./venv-release-dhib*/bin/activate
+# Ensure the release virtual environment is deactivated when the script exits
+trap 'deactivate 2>/dev/null || true' EXIT INT TERM
 deephaven server
-deactivate

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Exit on any error, undefined variable, or error in a pipeline
+set -e
+set -u
+set -o pipefail
+
 # Convenience script to build a release virtual environment and start the Deephaven server.
 # This script automates the process of:
 # 1. Creating a temporary installer virtual environment

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -36,7 +36,7 @@ pip install -r requirements_dhib_env.txt
 
 # Build the release virtual environment
 # This creates venv-release-dhib-<version> with all required packages
-python ./dhib_env.py release 
+python ./dhib_env.py release
 
 # Clean up temporary installer venv
 deactivate

--- a/dhib_env.py
+++ b/dhib_env.py
@@ -338,9 +338,9 @@ def venv_path(is_release: bool, dh_version: str, dh_ib_version: str) -> Path:
         The path to the new virtual environment.
     """
     if is_release:
-        return Path(f"venv-release-dhib={dh_version}").absolute()
+        return Path(f"venv-release-dhib-{dh_version}").absolute()
     else:
-        return Path(f"venv-dev-dhib={dh_ib_version}-dh={dh_version}").absolute()
+        return Path(f"venv-dev-dhib-{dh_ib_version}-dh-{dh_version}").absolute()
 
 
 ########################################################################################################################
@@ -578,12 +578,12 @@ def dev(
         logging.warning(f"Using system python: {python}")
         pyenv = Pyenv(python)
 
+    logging.warning(f"Installing deephaven-server: {dh_version}")
+    pyenv.pip_install("deephaven-server", f"~={dh_version}")
+
     ib_wheel = IbWheel(ib_version)
     ib_wheel.build(pyenv)
     ib_wheel.install(pyenv)
-
-    logging.warning(f"Installing deephaven-server: {dh_version}")
-    pyenv.pip_install("deephaven-server", f"~={dh_version}")
 
     if install_dhib:
         if use_dev:
@@ -649,12 +649,12 @@ def release(
         logging.warning(f"Using system python: {python}")
         pyenv = Pyenv(python)
 
+    logging.warning(f"Installing deephaven-server: {dh_version}")
+    pyenv.pip_install("deephaven-server", f"~={dh_version}")
+
     ib_wheel = IbWheel(ib_version)
     ib_wheel.build(pyenv)
     ib_wheel.install(pyenv)
-
-    logging.warning(f"Installing deephaven-server: {dh_version}")
-    pyenv.pip_install("deephaven-server", f"~={dh_version}")
 
     logging.warning(f"Installing deephaven-ib from PyPI: {dh_ib_version}")
     pyenv.pip_install("deephaven-ib", f"=={dh_ib_version}")


### PR DESCRIPTION
Add convenience script for quick setup and improve installation process (#137)

Add `build_and_run.sh` convenience script for one-command environment setup and server startup, update README with quick start instructions, fix virtual environment path naming to use hyphens instead of equals signs, and reorder package installation to install deephaven-server before ibapi to improve dependency resolution.