### PR TITLE
feat: Update default Deephaven version to 41.1

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   IB_VERSION: 10.19.04
-  DH_VERSION: 0.34.1
+  DH_VERSION: 41.1
 
 jobs:
   build-ib-whl:
@@ -70,7 +70,6 @@ jobs:
     - name: Build
       env:
         DH_IB_VERSION: ${{ steps.version.outputs.version }}
-        DH_VERSION: ${{ env.DH_VERSION }}
       run: |
         python -m build
     - name: Archive build artifacts

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   IB_VERSION: 10.19.04
-  DH_VERSION: 41.1
+  DH_VERSION: "41.1"
 
 jobs:
   build-ib-whl:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This pull request updates the build workflow configuration, specifically by updating the `DH_VERSION` environment variable and removing a redundant environment variable assignment in the build job.

Dependency version update:

* Updated the `DH_VERSION` environment variable from `0.34.1` to `41.1` in `.github/workflows/build-and-publish.yml` to ensure the workflow uses the latest version.

Workflow simplification:

* Removed the explicit assignment of `DH_VERSION` in the build job's environment, as it is now set globally.