### PR TITLE
fix: Correct virtual environment cleanup path

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -23,7 +23,7 @@ echo "JAVA_HOME=${JAVA_HOME}"
 # Clean up any existing virtual environments
 deactivate 2>/dev/null || true  # Deactivate if already in a venv
 rm -rf .venv-installer
-rm -rf venv-release-dhib*
+rm -rf .venv-release-dhib*
 
 # Create temporary installer virtual environment
 # This small venv is only used to run the dhib_env.py script


### PR DESCRIPTION
This pull request makes a minor update to the cleanup logic in the `build_and_run.sh` script. The change ensures that the script removes the correct virtual environment directory by updating the pattern to `.venv-release-dhib*` instead of `venv-release-dhib*`.